### PR TITLE
Eureka Scan Report outputted as a Github PR comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,12 +34,16 @@ runs:
     - name: Run Eureka scan
       shell: bash
       run: |
+        PR_REPORT_DOCKER_FLAGS=""
+        if [[ "${{ inputs.pr_report }}" == "true" ]]; then
+          PR_REPORT_DOCKER_FLAGS="-v \"${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka\" -e EUREKA_OUTPUT=/tmp/eureka/summary.log"
+        fi
+
         docker run --rm --network host \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e DIND_USER_HOME="$(pwd)" \
-          -v "${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka" \
-          -e EUREKA_OUTPUT=/tmp/eureka/summary.log \
+          ${PR_REPORT_DOCKER_FLAGS} \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \
           -e EUREKA_PASSWORD="${EUREKA_PASSWORD}" \

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
         echo "Eureka scan did not complete!" > $TMPDIR/summary.log
         echo "report_file=$TMPDIR/summary.log" >> "$GITHUB_OUTPUT"        
         echo "tmpdir=$TMPDIR" >> "$GITHUB_OUTPUT"
-        
+    
     - name: Pull down Eureka container
       shell: bash
       run: |
@@ -33,7 +33,7 @@ runs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e DIND_USER_HOME="$(pwd)" \
-          -v "${{ steps.report_prep.output.tmpdir }}:/tmp/eureka" \
+          -v "${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka" \
           -e EUREKA_OUTPUT=/tmp/eureka/summary.log \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \
@@ -45,4 +45,4 @@ runs:
       if: always()
       uses: mshick/add-pr-comment@v2
       with:
-        message-path: ${{ steps.report_prep.output.report_file }}
+        message-path: ${{ steps.report_prep.outputs.report_file }}

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,15 @@ runs:
       run: |
         docker login -u ${EUREKA_USER} -p ${EUREKA_PASSWORD} ${EUREKA_REGISTRY_URL}
 
+    - name: Preparing summary report
+      shell: bash
+      id: report_prep
+      run: |
+        TMPDIR=$(mktemp -d)
+        echo "Eureka scan did not complete!" > $TMPDIR/summary.log
+        echo "report_file=$TMPDIR/summary.log" >> "$GITHUB_OUTPUT"        
+        echo "tmpdir=$TMPDIR" >> "$GITHUB_OUTPUT"
+        
     - name: Pull down Eureka container
       shell: bash
       run: |
@@ -24,8 +33,16 @@ runs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e DIND_USER_HOME="$(pwd)" \
+          -v ${{ steps.report_prep.output.tmpdir }}:/tmp/eureka \
+          -e EUREKA_OUTPUT=/tmp/eureka/summary.log \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \
           -e EUREKA_PASSWORD="${EUREKA_PASSWORD}" \
           -e PROFILE_INFO="${PROFILE_INFO}" \
           ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG} 
+
+    - name: Write Eureka report to comment
+      if: always()
+      uses: mshick/add-pr-comment@v2
+      with:
+        message-path: ${{ steps.report_prep.output.report_file }}

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: "Eureka DevSecops"
 description: "Scan your code with Eureka DevSecOps to discover potential security risks and vulnerabilities"
 inputs:
-  args:
-    description: "Additional Eureka DevSecOps CLI arguments"
-    required: false
   pr_report:
     description: "Enable a Eureka scan report as a comment in the pull request"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e DIND_USER_HOME="$(pwd)" \
-          -v ${{ steps.report_prep.output.tmpdir }}:/tmp/eureka \
+          -v "${{ steps.report_prep.output.tmpdir }}:/tmp/eureka" \
           -e EUREKA_OUTPUT=/tmp/eureka/summary.log \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
         REPORT_TMPDIR="${{ steps.report_prep.outputs.tmpdir }}"
 
         if [[ "$INPUT_PR_REPORT" == "true" ]]; then
-          echo "PR_REPORT_DOCKER_FLAGS=-v '${REPORT_TMPDIR}:/tmp/eureka' -e EUREKA_OUTPUT=/tmp/eureka/summary.log" >> $GITHUB_ENV
+          echo "PR_REPORT_DOCKER_FLAGS=-v "${REPORT_TMPDIR}:/tmp/eureka" -e EUREKA_OUTPUT=/tmp/eureka/summary.log" >> $GITHUB_ENV
         else
           echo "PR_REPORT_DOCKER_FLAGS=" >> $GITHUB_ENV
         fi

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   args:
     description: "Additional Eureka DevSecOps CLI arguments"
     required: false
+  pr_report:
+    description: "Enable a Eureka scan report as a comment in the pull request"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -15,6 +19,7 @@ runs:
     - name: Preparing summary report
       shell: bash
       id: report_prep
+      if: inputs.pr_report == 'true'
       run: |
         TMPDIR=$(mktemp -d)
         echo "Eureka scan did not complete!" > $TMPDIR/summary.log
@@ -42,7 +47,7 @@ runs:
           ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG} 
 
     - name: Write Eureka report to comment
-      if: always()
+      if: inputs.pr_report == 'true'
       uses: mshick/add-pr-comment@v2
       with:
         message-path: ${{ steps.report_prep.outputs.report_file }}

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "Eureka DevSecops"
 description: "Scan your code with Eureka DevSecOps to discover potential security risks and vulnerabilities"
 inputs:
-  pr_report:
+  enable_pr_scan_report:
     description: "Enable a Eureka scan report as a comment in the pull request"
     required: false
     default: "false"
@@ -16,7 +16,7 @@ runs:
     - name: Preparing summary report
       shell: bash
       id: report_prep
-      if: inputs.pr_report == 'true'
+      if: inputs.enable_pr_scan_report == 'true'
       run: |
         TMPDIR=$(mktemp -d)
         echo "Eureka scan did not complete!" > $TMPDIR/summary.log
@@ -25,9 +25,9 @@ runs:
     
     - name: Set GitHub pull request Eureka scan report docker flags
       shell: bash
-      if : inputs.pr_report == 'true'
+      if : inputs.enable_pr_scan_report == 'true'
       run: |
-        INPUT_PR_REPORT="${{ inputs.pr_report }}"
+        INPUT_PR_REPORT="${{ inputs.enable_pr_scan_report }}"
         REPORT_TMPDIR="${{ steps.report_prep.outputs.tmpdir }}"
 
         if [[ "$INPUT_PR_REPORT" == "true" ]]; then
@@ -51,7 +51,7 @@ runs:
           ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG}
 
     - name: Write Eureka report to comment
-      if: ${{ inputs.pr_report == 'true' && always() }}
+      if: ${{ inputs.enable_pr_scan_report == 'true' && always() }}
       uses: mshick/add-pr-comment@v2
       with:
         message-path: ${{ steps.report_prep.outputs.report_file }}

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,11 @@ runs:
       shell: bash
       if : inputs.pr_report == 'true'
       run: |
-        if [[ "${{ inputs.pr_report }}" == "true" ]]; then
-          echo "PR_REPORT_DOCKER_FLAGS=-v '${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka' -e EUREKA_OUTPUT=/tmp/eureka/summary.log" >> $GITHUB_ENV
+        INPUT_PR_REPORT="${{ inputs.pr_report }}"
+        REPORT_TMPDIR="${{ steps.report_prep.outputs.tmpdir }}"
+
+        if [[ "$INPUT_PR_REPORT" == "true" ]]; then
+          echo "PR_REPORT_DOCKER_FLAGS=-v '${REPORT_TMPDIR}:/tmp/eureka' -e EUREKA_OUTPUT=/tmp/eureka/summary.log" >> $GITHUB_ENV
         else
           echo "PR_REPORT_DOCKER_FLAGS=" >> $GITHUB_ENV
         fi

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
           ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG}
 
     - name: Write Eureka report to comment
-      if: inputs.pr_report == 'true'
+      if: ${{ inputs.pr_report == 'true' && always() }}
       uses: mshick/add-pr-comment@v2
       with:
         message-path: ${{ steps.report_prep.outputs.report_file }}

--- a/action.yml
+++ b/action.yml
@@ -26,29 +26,29 @@ runs:
         echo "report_file=$TMPDIR/summary.log" >> "$GITHUB_OUTPUT"        
         echo "tmpdir=$TMPDIR" >> "$GITHUB_OUTPUT"
     
-    - name: Pull down Eureka container
+    - name: Set GitHub pull request Eureka scan report docker flags
       shell: bash
+      if : inputs.pr_report == 'true'
       run: |
-        docker pull ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG}
+        if [[ "${{ inputs.pr_report }}" == "true" ]]; then
+          echo "PR_REPORT_DOCKER_FLAGS=-v '${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka' -e EUREKA_OUTPUT=/tmp/eureka/summary.log" >> $GITHUB_ENV
+        else
+          echo "PR_REPORT_DOCKER_FLAGS=" >> $GITHUB_ENV
+        fi
 
     - name: Run Eureka scan
       shell: bash
       run: |
-        PR_REPORT_DOCKER_FLAGS=""
-        if [[ "${{ inputs.pr_report }}" == "true" ]]; then
-          PR_REPORT_DOCKER_FLAGS="-v \"${{ steps.report_prep.outputs.tmpdir }}:/tmp/eureka\" -e EUREKA_OUTPUT=/tmp/eureka/summary.log"
-        fi
-
         docker run --rm --network host \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e DIND_USER_HOME="$(pwd)" \
-          ${PR_REPORT_DOCKER_FLAGS} \
+          $PR_REPORT_DOCKER_FLAGS \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \
           -e EUREKA_PASSWORD="${EUREKA_PASSWORD}" \
           -e PROFILE_INFO="${PROFILE_INFO}" \
-          ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG} 
+          ${EUREKA_REGISTRY_URL}/${EUREKA_REPO}:${EUREKA_TAG}
 
     - name: Write Eureka report to comment
       if: inputs.pr_report == 'true'


### PR DESCRIPTION
### Changes

Integrates workflow steps for Eureka scan report to be outputted as a GitHub PR comment. 
Uses a `enable_pr_scan_report` input argument with a value of `true` to enable the steps that generate the report.

### Screenshots 

<img width="836" alt="image" src="https://github.com/user-attachments/assets/97eb7aea-fa9b-4d8f-8bf6-99c0cf64a006" />

### Steps to Test

1. Add Eureka DevSecOps GitHub action to an existing GitHub workflow file
2. Ensure that secrets and repository variables are configured to run Eureka
3. Ensure that the `enable_pr_scan_report` input argument as added with a value of `true`
4. Trigger the workflow with a pull request event