### PR TITLE
Add inputs for scanner specific environment variables for the docker run command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,30 @@
 name: "Eureka DevSecOps"
 description: "Scan your code with Eureka DevSecOps to discover potential security risks and vulnerabilities"
+inputs:
+  synk_token:
+    description: "Synk scanner API token"
+    required: false
+    default: ""
+  sonarqube_token:
+    description: "SonarQube user security token"
+    required: false
+    default: ""
+  veracode_api_key_id:
+    description: "Veracode SAST/SCA/Pipeline API key ID"
+    required: false
+    default: ""
+  veracode_api_key_secret:
+    description: "Veracode SAST/SCA/Pipeline API key secret"
+    required: false
+    default: ""
+  zap_username:
+    description: "ZAP API username"
+    required: false
+    default: ""
+  zap_password:
+    description: "ZAP API password"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -19,6 +44,12 @@ runs:
         docker run --rm --network host \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
+          -e SNYK_TOKEN="${{ inputs.snyk_token }}" \
+          -e SONARQUBE_TOKEN="${{ inputs.sonarqube_token }}" \
+          -e VERACODE_API_KEY_ID="${{ inputs.veracode_api_key_id }}" \
+          -e VERACODE_API_KEY_SECRET="${{ inputs.veracode_api_key_secret }}" \
+          -e DAST_USERNAME="${{ inputs.zap_username }}" \
+          -e DAST_PASSWORD="${{ inputs.zap_password }}" \
           -e DIND_USER_HOME="$(pwd)" \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \

--- a/action.yml
+++ b/action.yml
@@ -17,12 +17,12 @@ inputs:
     description: "Veracode SAST/SCA/Pipeline API key secret"
     required: false
     default: ""
-  zap_username:
-    description: "ZAP API username"
+  dast_username:
+    description: "Username credential for DAST scanners such as Zap"
     required: false
     default: ""
-  zap_password:
-    description: "ZAP API password"
+  dast_password:
+    description: "Password credential for DAST scanners such as Zap"
     required: false
     default: ""
 runs:
@@ -48,8 +48,8 @@ runs:
           -e SONAR_USER_TOKEN="${{ inputs.sonarqube_user_token }}" \
           -e VERACODE_API_KEY_ID="${{ inputs.veracode_api_key_id }}" \
           -e VERACODE_API_KEY_SECRET="${{ inputs.veracode_api_key_secret }}" \
-          -e DAST_USERNAME="${{ inputs.zap_username }}" \
-          -e DAST_PASSWORD="${{ inputs.zap_password }}" \
+          -e DAST_USERNAME="${{ inputs.dast_username }}" \
+          -e DAST_PASSWORD="${{ inputs.dast_password }}" \
           -e DIND_USER_HOME="$(pwd)" \
           -e EUREKA_ENDPOINT="${EUREKA_ENDPOINT}" \
           -e EUREKA_USER="${EUREKA_USER}" \

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: "Eureka DevSecOps"
 description: "Scan your code with Eureka DevSecOps to discover potential security risks and vulnerabilities"
 inputs:
-  synk_token:
-    description: "Synk scanner API token"
+  snyk_token:
+    description: "Snyk scanner API token"
     required: false
     default: ""
   sonarqube_user_token:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Synk scanner API token"
     required: false
     default: ""
-  sonarqube_token:
+  sonarqube_user_token:
     description: "SonarQube user security token"
     required: false
     default: ""
@@ -45,7 +45,7 @@ runs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v "$(pwd)":/home/repo \
           -e SNYK_TOKEN="${{ inputs.snyk_token }}" \
-          -e SONARQUBE_TOKEN="${{ inputs.sonarqube_token }}" \
+          -e SONAR_USER_TOKEN="${{ inputs.sonarqube_user_token }}" \
           -e VERACODE_API_KEY_ID="${{ inputs.veracode_api_key_id }}" \
           -e VERACODE_API_KEY_SECRET="${{ inputs.veracode_api_key_secret }}" \
           -e DAST_USERNAME="${{ inputs.zap_username }}" \


### PR DESCRIPTION
Adds inputs that are required as an environment variable in the docker run command by specific scanners. 
If using a certain scanner, or if it is enabled for the configured then the appropriate input must be passed.
Next steps is updating README to reflect these additional inputs.